### PR TITLE
Match undef test

### DIFF
--- a/lib/Symbol/Approx/Sub.pm
+++ b/lib/Symbol/Approx/Sub.pm
@@ -382,7 +382,7 @@ sub _make_AUTOLOAD {
       ) unless defined &{$CONF{match}};
       @match_ind = $CONF{match}->(@subs);
     } else {
-      @match_ind = @subs[1 .. $#subs];
+      @match_ind = (0 .. $#subs - 1);
     }
 
     shift @subs;

--- a/t/match_undef.t
+++ b/t/match_undef.t
@@ -1,0 +1,33 @@
+use Test::More qw(); 
+#Don't import anything or test routines become potential matches during the test
+
+use Symbol::Approx::Sub (
+    xform => undef,
+    match => undef
+);
+
+sub aa { 'aa' }
+
+sub bb { 'bb' }
+
+sub cc { 'cc' }
+
+my $total_tries = 1000;
+my $tries_left = $total_tries;
+
+my %remaining_returns = (
+    'aa' => 1,
+    'bb' => 1,
+    'cc' => 1,
+);
+
+while($tries_left >= 0) {
+    my $ret_val = b();
+    delete $remaining_returns{$ret_val};
+    last if !keys %remaining_returns;
+    $tries_left--;
+}
+
+Test::More::ok !keys %remaining_returns, "Got all expected return values (covering all our subroutines) in <= $total_tries tries";
+
+Test::More::done_testing();


### PR DESCRIPTION
This tests the case in which match is set to undef

It does this by calling an autoloaded function many times, and making sure that we get an expected value from each of the functions at some point.

I couldn't figure out a better way to introspect the match functions available to the chooser function so used this approach

This test exposed a bug which I am providing a fix for in a separate pull request in the off chance you want to apply them separately (want to apply the fix, and use the test to verify broken behavior, but not use the particular test as implemented in the test suite)
