### PR TITLE
Bug fix for match => undef case

### DIFF
--- a/lib/Symbol/Approx/Sub.pm
+++ b/lib/Symbol/Approx/Sub.pm
@@ -382,7 +382,7 @@ sub _make_AUTOLOAD {
       ) unless defined &{$CONF{match}};
       @match_ind = $CONF{match}->(@subs);
     } else {
-      @match_ind = @subs[1 .. $#subs];
+      @match_ind = (0 .. $#subs - 1);
     }
 
     shift @subs;


### PR DESCRIPTION
Need to provide indexes back, not sub names

Offsets need to reflect indexes of items after an item is shifted off
