### PR TITLE
Choose sub test and fix

### DIFF
--- a/lib/Symbol/Approx/Sub.pm
+++ b/lib/Symbol/Approx/Sub.pm
@@ -330,7 +330,7 @@ sub _set_chooser {
 
   my $type = ref $param->{choose};
   if ($type eq 'CODE') {
-    $CONF->{chooser} = $param->{chooser};
+    $CONF->{choose} = $param->{choose};
   } elsif ($type eq '') {
     my $mod = "Symbol::Approx::Sub::$param->{choose}";
     load $mod;

--- a/t/choose_sub.t
+++ b/t/choose_sub.t
@@ -1,0 +1,29 @@
+use Test::More qw(); 
+#Don't import anything or test routines become potential matches during the test
+
+my $CHOOSE_SUB_USED = 0;
+
+use Symbol::Approx::Sub (
+    xform => undef,
+    match => sub {
+        my($sub, @subs) = @_;
+        return (0..$#subs);
+    },
+
+    choose => sub {
+        $CHOOSE_SUB_USED++;
+        return 0;
+    },
+);
+
+sub aa { 'aa' }
+
+sub bb { 'bb' }
+
+b();
+c();
+
+Test::More::ok $CHOOSE_SUB_USED,    "Choose sub provided used to choose from matches";
+Test::More::is $CHOOSE_SUB_USED, 2, "Choose sub used expected number of times";
+
+Test::More::done_testing();


### PR DESCRIPTION
Since the test alone, showed the broken build -- providing a pull request that contains both the fix and the new test

Fix:
Currently it checks the type of $param->{choose} to check if it's code
and in that block then set $param->{chooser} (which may not be of type CODE)
Documentation specifies using choose => sub {} and that's what seems to
actually work with a new test of functionality

Test:
Providing a test which shows the broken case which spits out an exception of: Invalid chooser passed to Symbol::Approx::Sub w/o the fix above (this may potentially need to be landed with fixes for match => undef too)

If you'd like pull requests provided in different chunks of work just let me know
